### PR TITLE
Add helper to read CSV file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { readFileSync } from "node:fs";
 import { postRecord, allPosts, PostRecord } from "./schema.js";
 
 // CSV parsing helper function
 function parseCSV(csvText: string): PostRecord[] {
-	const lines = csvText.split('\n');
-	const headers = lines[0].split(',');
+        const lines = csvText.split('\n');
+        const headers = lines[0].split(',');
 	
 	return lines.slice(1)
 		.filter((line: string) => line.trim())
@@ -17,7 +18,13 @@ function parseCSV(csvText: string): PostRecord[] {
 				post[header] = values[index] || '';
 			});
 			return post as PostRecord;
-		});
+                });
+}
+
+// CSV file reading helper function
+function readCSVFile(filePath: string): PostRecord[] {
+       const csvText = readFileSync(filePath, "utf8");
+       return parseCSV(csvText);
 }
 
 


### PR DESCRIPTION
## Summary
- add Node `fs` dependency to imports
- provide `readCSVFile` helper that loads a CSV and parses it

## Testing
- `npm run format` *(fails: biome not found)*
- `npm run lint:fix` *(fails: biome not found)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68687a6547b48328ba56766b2750f129